### PR TITLE
debian: postinst: Update debian postinst script 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vicharak-config (0.1.5) jammy; urgency=medium
+
+  * debian: postinst: Update debian postinst script
+
+ -- shailparmar03 <shailparmar26@gmail.com>  Tue, 05 Nov 2024 11:31:33 +0530
+
 vicharak-config (0.1.4) jammy; urgency=medium
 
   * debian: postinst: Fix debian postinst script

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,7 +2,10 @@
 set -e
 
 board=$(cat /sys/firmware/devicetree/base/model | awk '{print tolower($3)}')
-echo "deb http://apt.vicharak.in/ stable main" > /etc/apt/sources.list.d/vicharak.list
-echo "deb http://apt.vicharak.in/ stable-${board} ${board}" >> /etc/apt/sources.list.d/vicharak.list
+
+if ! grep -q "${board}" /etc/apt/sources.list.d/vicharak.list; then
+    echo "deb http://apt.vicharak.in/ stable main" > /etc/apt/sources.list.d/vicharak.list
+    echo "deb http://apt.vicharak.in/ stable-${board} ${board}" >> /etc/apt/sources.list.d/vicharak.list
+fi
 
 exit 0


### PR DESCRIPTION
Update the post installation script so that the `Vicharak apt list` is only updated if the board specific entry is not found.
Previous revision used to cause error while building the `rootfs` using the `Vicharak SDK` as the `post installation script` for `vicharak-config` relies on `/sys/firmware/devicetree/base/model`, which is only available after kernel installation and system boot.