### PR TITLE
rtk_hciattach tool depends on vicharak-config package 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ dch: debian/changelog
 
 .PHONY: deb
 deb: debian
-	debuild --no-lintian --lintian-hook "lintian --suppress-tags bad-distribution-in-changes-file -- %p_%v_*.changes" --no-sign -b
+	debuild --no-sign -b
 	mv -t . -u ../${PROJECT}[-_]*
 
 .PHONY: release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vicharak-config (0.1.9) jammy; urgency=medium
+
+  * tool : Update rtk_hciattach for bluetooth
+
+ -- avi951 <avi.shihora.w23@gmail.com>  Mon, 27 Jan 2025 12:08:37 +0530
+
 vicharak-config (0.1.8) jammy; urgency=medium
 
   * debian: Add mountboot.sh to post installation script

--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Priority: standard
 Depends: device-tree-compiler,
          gdisk,
          parted,
+         rtk-hciattach,
          pkexec | policykit-1 (<< 122-1),
          whiptail,
          ${misc:Depends},

--- a/src/usr/lib/vicharak-config/cli/u-boot-menu.sh
+++ b/src/usr/lib/vicharak-config/cli/u-boot-menu.sh
@@ -187,7 +187,7 @@ reset_overlays() {
 
 parse_dtbo() {
 	local output
-	output="$(dtc -I dtb -O dts "$1" 2>/dev/null | dtc -I dts -O yaml 2>/dev/null | yq -r ".[0].metadata.$2[0]" | tr '\0' '\n')"
+	output="$(dtc -I dtb -O dts "$1" 2>/dev/null | dtc -I dts -O yaml 2>/dev/null | yq -r ".[0][].__overlay__.metadata.$2[0]" | tr '\0' '\n')"
 
 	if [[ "${output}" == "null" ]]; then
 		# Try parsing the metadata property with an alternative path


### PR DESCRIPTION
A common method to install rtk_hciattach tool for Vaaman and Axon if it depends on vicharak-config