### PR TITLE
cleanup: remove mountboot.sh creation from postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -8,31 +8,6 @@ if ! grep -q "${board}" /etc/apt/sources.list.d/vicharak.list; then
     echo "deb http://apt.vicharak.in/ stable-${board} ${board}" >> /etc/apt/sources.list.d/vicharak.list
 fi
 
-cat > "/etc/init.d/mountboot.sh" <<EOF
-#!/bin/sh
-
-set -e
-
-__get_root_dev() {
-        realpath "\$(findmnt --nofsroot --noheadings --output SOURCE /)"
-}
-
-__get_block_dev() {
-        echo "/dev/\$(udevadm info --query=path "--name=\$(__get_root_dev)" | awk -F'/' '{print \$(NF-1)}')"
-}
-
-dev=\$(__get_block_dev)
-
-boot_part=\$(parted -s "\${dev}" print | grep -w "boot" | awk '{print \$1}')
-
-# Mount the boot partition
-echo "Mounting boot partition  \${dev}p\${boot_part} to /boot"
-mount "\${dev}p\${boot_part}" /boot
-
-echo "Mount operation completed successfully."
-EOF
-	chmod 0755 "/etc/init.d/mountboot.sh"
-
 systemctl daemon-reload && systemctl enable --now advanced-usb@tethering
 
 exit 0


### PR DESCRIPTION
This commit removes the logic for writing mountboot.sh in debian/postinst, as the script is already included in the image. Keeping it in postinst is redundant and unnecessary.