### PR TITLE
debian: clean up postinst and update changelog for 0.1.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+vicharak-config (0.1.11) jammy; urgency=medium
+
+  * Remove systemctl daemon-reload call from postinst script.
+    This avoids failures during installation in Docker and other
+    minimal environments without systemd.
+
+ -- peonix0 <ajeetsinghchahar2@gmail.com>  Fri, 4 Jul 2025 12:08:37 +0530
+
 vicharak-config (0.1.10) jammy; urgency=medium
 
   * tui: advanced: Add support for USB tethering

--- a/debian/postinst
+++ b/debian/postinst
@@ -8,6 +8,4 @@ if ! grep -q "${board}" /etc/apt/sources.list.d/vicharak.list; then
     echo "deb http://apt.vicharak.in/ stable-${board} ${board}" >> /etc/apt/sources.list.d/vicharak.list
 fi
 
-systemctl daemon-reload
-
 exit 0


### PR DESCRIPTION
* Remove redundant systemctl daemon-reload from postinst script to prevent issues in environments without systemd (e.g., Docker).
* Update debian/changelog for the 0.1.11 release