### PR TITLE
Remove unnecesssary gl4es configs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+vicharak-config (0.1.14) jammy; urgency=medium
+
+  * Remove unnecessary gl4es configs
+ -- Vasu Singh <vasucp1207@gmail.com> Wed, 30 Jul 2025 11:46:01 +0530
+
 vicharak-config (0.1.13) jammy; urgency=medium
 
   * tui: overlay: Remove unwanted debugging lines

--- a/src/usr/lib/vicharak-config/cli/gpu.sh
+++ b/src/usr/lib/vicharak-config/cli/gpu.sh
@@ -23,32 +23,3 @@ install_gpu() {
 	fi
 	apt install /userdata/gpu/*.deb || true
 }
-
-enable_gpu_opengl() {
-	__parameter_count_check 0 "$@"
-
-	# shellcheck disable=SC2016
-	echo '
-#!/bin/bash
-
-shopt -s nullglob
-
-export LD_LIBRARY_PATH="/usr/lib/gl4es:${LD_LIBRARY_PATH}"
-
-exec "$@"
-' >/usr/bin/gl4es
-
-	if [ -f /usr/bin/gl4es ]; then
-		chmod +x /usr/bin/gl4es
-	else
-		echo "Failed to create /usr/bin/gl4es"
-	fi
-}
-
-disable_gpu_opengl() {
-	__parameter_count_check 0 "$@"
-
-	if [ -f /usr/bin/gl4es ]; then
-		rm -f /usr/bin/gl4es
-	fi
-}

--- a/src/usr/lib/vicharak-config/tui/advanced/gpu/gpu.sh
+++ b/src/usr/lib/vicharak-config/tui/advanced/gpu/gpu.sh
@@ -18,26 +18,6 @@ __advanced_gpu_install() {
 	fi
 }
 
-__advanced_gpu_enable_opengl() {
-	if yesno "Are you sure to enable OpenGL support for Rockchip Mali gpu?"; then
-		if enable_gpu_opengl; then
-			msgbox "Enabled OpenGL support for Rockchip Mali gpu.\n\nUse 'gl4es' prefix to run OpenGL applications."
-		else
-			msgbox "Failed to enable OpenGL support for Rockchip Mali gpu."
-		fi
-	fi
-}
-
-__advanced_gpu_disable_opengl() {
-	if yesno "Are you sure to disable OpenGL support for Rockchip Mali gpu?"; then
-		if disable_gpu_opengl; then
-			msgbox "Disabled OpenGL support for Rockchip Mali gpu."
-		else
-			msgbox "Failed to disable OpenGL support for Rockchip Mali gpu."
-		fi
-	fi
-}
-
 __advanced_gpu() {
 	menu_init
 
@@ -45,12 +25,6 @@ __advanced_gpu() {
 		menu_add __advanced_gpu_uninstall "Uninstall Rockchip Mali gpu"
 	else
 		menu_add __advanced_gpu_install "Install Rockchip Mali gpu"
-	fi
-
-	if [ -f /usr/bin/gl4es ]; then
-		menu_add __advanced_gpu_disable_opengl "Disable OpenGL support for Rockchip Mali gpu"
-	else
-		menu_add __advanced_gpu_enable_opengl "Enable OpenGL support for Rockchip Mali gpu"
 	fi
 
 	menu_show "Please select an option below:"


### PR DESCRIPTION
There is no need for GL4ES, since Mesa3D already supports up to OpenGL 3.1. This GL4ES solution does not even work properly.