### PR TITLE
build(deps): dependency of vicharak-user

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Section: admin
 Priority: standard
 Depends: device-tree-compiler,
          gdisk,
-         parted,
+         parted, vicharak-user, 
          rtk-hciattach,
          pkexec | policykit-1 (<< 122-1),
          whiptail,


### PR DESCRIPTION
- This commit adds the dependency of vicharak-user package.
- vicharak-user installs a binary along with a public server key into vicharak-config directory 
  for user verification during installation of vicharak's softwares. 
- Other packages execute the binary during their pre-installation phase