### PR TITLE
advanced: support to toggle U-Boot console access

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vicharak-config (0.1.16) jammy; urgency=medium
+
+  * advanced: support for toggling uboot console access
+
+ -- Brajesh Patil <brajeshpatil11@gmail.com>  Mon, 08 Sep 2025 18:54:05 +0530
+
 vicharak-config (0.1.15) jammy; urgency=medium
 
   * dependency addition: vicharak-user

--- a/src/usr/lib/vicharak-config/tui/advanced/advanced.sh
+++ b/src/usr/lib/vicharak-config/tui/advanced/advanced.sh
@@ -12,6 +12,8 @@ source "/usr/lib/vicharak-config/tui/advanced/display/display.sh"
 source "/usr/lib/vicharak-config/tui/advanced/vnc/vncserver.sh"
 # shellcheck source=src/usr/lib/vicharak-config/tui/advanced/usb/usb.sh
 source "/usr/lib/vicharak-config/tui/advanced/usb/usb.sh"
+# shellcheck source=src/usr/lib/vicharak-config/tui/advanced/uboot/main.sh
+source "/usr/lib/vicharak-config/tui/advanced/uboot/main.sh"
 
 __advanced() {
 	menu_init
@@ -21,5 +23,6 @@ __advanced() {
 	menu_add __advanced_vncserver "VNC Server"
 	#menu_add __advanced_ssh             "SSH"
 	menu_add __advanced_usb "USB Advanced features"
+	menu_add __advanced_uboot "Boot Settings"
 	menu_show "Please select an option below:"
 }

--- a/src/usr/lib/vicharak-config/tui/advanced/uboot/console.sh
+++ b/src/usr/lib/vicharak-config/tui/advanced/uboot/console.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+
+SECTOR=16000			# Sector on eMMC where U-Boot status is stored
+OFFSET=$((SECTOR * 512))	# Convert sector to byte offset
+CONSOLE_MAGIC="\x80\x00\x85"	# Magic value to toggle access to U-Boot CLI
+
+# Read first 3 bytes at the OFFSET on eMMC and determine console status
+get_uboot_console_status() {
+	magic=$(sudo dd if=/dev/mmcblk0 bs=1 skip=$OFFSET count=3 2>/dev/null | hexdump -v -e '3/1 "%02x" "\n"')
+	CONSOLE_MAGIC_STR=${CONSOLE_MAGIC//\\x/}
+
+	# Determine console status based on magic value
+	case "$magic" in
+		"$CONSOLE_MAGIC_STR") 	echo "disabled" ;;
+		*)			echo "enabled" ;;
+	esac
+}
+
+# Write 3 bytes of zeros at the OFFSET to enable the console
+enable_uboot_console() {
+	printf "\x00\x00\x00" | dd of=/dev/mmcblk0 bs=1 seek=$OFFSET conv=notrunc 2>/dev/null
+	msgbox "Boot Console Enabled"
+}
+
+# Write the "disabled magic" to the device
+disable_uboot_console() {
+	# shellcheck disable=SC2059
+	printf "$CONSOLE_MAGIC" | dd of=/dev/mmcblk0 bs=1 seek=$OFFSET conv=notrunc 2>/dev/null
+	msgbox "Boot Console Disabled"
+}
+
+# Provides a TUI for enabling/disabling U-Boot console
+__uboot_console() {
+	# Check the current console status and set default radio button states
+	status=$(get_uboot_console_status)
+
+	if [ "$status" = "disabled" ]; then
+		default_disable=ON
+		default_enable=OFF
+	else
+		default_disable=OFF
+		default_enable=ON
+	fi
+
+	# Initialize the radiolist UI
+	radiolist_init
+
+	# Add options to the radiolist
+	radiolist_add "Boot console enabled" "$default_enable"
+	radiolist_add "Boot console disabled" "$default_disable"
+
+	# Message to show if no options exist
+	radiolist_emptymsg "No console options found."
+
+	# Display the radiolist and allow user to select
+	if ! radiolist_show "Select Boot console mode:\n        Enable or Disable the Boot console. Disabling blocks interrupts and access to Boot CLI."; then
+		return
+	fi
+
+	selected_option="${VICHARAK_CONFIG_RADIOLIST_STATE_NEW[0]}"
+
+	# Execute the appropriate function based on selection
+	case "$selected_option" in
+		0) enable_uboot_console;;
+		1) disable_uboot_console;;
+	esac
+}

--- a/src/usr/lib/vicharak-config/tui/advanced/uboot/main.sh
+++ b/src/usr/lib/vicharak-config/tui/advanced/uboot/main.sh
@@ -1,0 +1,10 @@
+# shellcheck shell=bash
+
+# shellcheck source=src/usr/lib/vicharak-config/tui/advanced/uboot/console.sh
+source "/usr/lib/vicharak-config/tui/advanced/uboot/console.sh"
+
+__advanced_uboot() {
+	menu_init
+	menu_add __uboot_console "Boot Console Access (Enable/Disable)"
+	menu_show "Please select an option below:"
+}


### PR DESCRIPTION
- Introduce a new "Boot Settings" menu in the advanced section
- Add console.sh to enable/disable U-Boot console by writing to eMMC
- Implement main.sh in case other Boot settings need to be added
- Update changelog for version 0.1.16