### PR TITLE
Recovery key service and supporting scripts added

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+vicharak-config (0.1.21) jammy; urgency=medium
+
+  * vicharak-config: tui: comm: Added hotspot management support
+  * vicharak-config: tui: comm: Added recovery-button-triggered hotspot service
+  * vicharak-config: tui: comm: Added TUI options for hotspot enable/disable, manual start, and credential editing
+  * vicharak-config: tui: comm: Added ADC-based recovery key monitoring and nmcli hotspot startup
+
+ -- Keshav Jha <keshav1499@gmail.com>  Fri, 22 May 2026 10:53:17 +0530
+
 vicharak-config (0.1.20) jammy; urgency=medium
 
   * remove unwanted dependencies

--- a/debian/vicharak-config.hotspot.service
+++ b/debian/vicharak-config.hotspot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Recovery Key Monitor Service
+After=network.target
+
+[Service]
+ExecStart=/bin/bash /usr/lib/vicharak-config/tui/comm/hotspot/recovery_key_monitor.sh
+Restart=always
+User=root
+
+# Important for hardware access
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/src/usr/lib/vicharak-config/tui/comm/comm.sh
+++ b/src/usr/lib/vicharak-config/tui/comm/comm.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+source "/usr/lib/vicharak-config/tui/comm/hotspot/hotspot.sh"
 
 __comm_network() {
 	nmtui
@@ -8,9 +9,14 @@ __comm_bluetooth() {
 	msgbox "Configure Bluetooth"
 }
 
+__comm_hotspot() {
+	__hotspot
+}
+
 __comm() {
 	menu_init
 	menu_add __comm_network "Network"
+	menu_add __comm_hotspot "Hotspot"
 	if $DEBUG; then
 		menu_add __comm_bluetooth "Bluetooth"
 	fi

--- a/src/usr/lib/vicharak-config/tui/comm/hotspot/hotspot.sh
+++ b/src/usr/lib/vicharak-config/tui/comm/hotspot/hotspot.sh
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+
+HOTSPOT_SERVICE="vicharak-config.hotspot.service"
+HOTSPOT_SCRIPT="/usr/lib/vicharak-config/tui/comm/hotspot/start_hotspot.sh"
+
+__hotspot_enable_recovery() {
+	sudo systemctl enable "$HOTSPOT_SERVICE"
+	sudo systemctl start "$HOTSPOT_SERVICE"
+	msgbox "Recovery button hotspot enabled"
+}
+
+__hotspot_disable_recovery() {
+	sudo systemctl stop "$HOTSPOT_SERVICE"
+	sudo systemctl disable "$HOTSPOT_SERVICE"
+	msgbox "Recovery button hotspot disabled"
+}
+
+__hotspot_start_now() {
+	sudo "$HOTSPOT_SCRIPT"
+	msgbox "Hotspot started manually"
+}
+
+__hotspot_edit_credentials() {
+	SSID=$(inputbox "Enter SSID" "HOTSPOT")
+	PASS=$(inputbox "Enter Password (min 8 chars)" "12345678")
+
+	if [ -z "$SSID" ] || [ -z "$PASS" ]; then
+		msgbox "Invalid input"
+		return
+	fi
+
+	sudo sed -i "s/^SSID=.*/SSID=\"$SSID\"/" "$HOTSPOT_SCRIPT"
+	sudo sed -i "s/^PASSWORD=.*/PASSWORD=\"$PASS\"/" "$HOTSPOT_SCRIPT"
+
+	msgbox "Credentials updated"
+}
+
+__hotspot() {
+	menu_init
+
+	menu_add __hotspot_recovery_enable  "Enable via Recovery Button"
+	menu_add __hotspot_recovery_disable "Disable Recovery Button"
+
+	menu_add __hotspot_manual           "Start Hotspot Now"
+	menu_add __hotspot_edit             "Edit Credentials"
+
+	menu_show "Hotspot Configuration"
+}

--- a/src/usr/lib/vicharak-config/tui/comm/hotspot/recovery_key_monitor.sh
+++ b/src/usr/lib/vicharak-config/tui/comm/hotspot/recovery_key_monitor.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ADC_PATH="/sys/bus/iio/devices/iio:device0/in_voltage1_raw"
+THRESHOLD=512
+SLEEP_INTERVAL=0.2
+
+LAST_STATE=1   # 1 = not pressed, 0 = pressed
+
+echo "[KEY_MONITOR] Started"
+
+while true; do
+    if [ ! -f "$ADC_PATH" ]; then
+        echo "[KEY_MONITOR] ADC path missing!"
+        sleep 1
+        continue
+    fi
+
+    ADC_VALUE=$(cat "$ADC_PATH")
+
+    if [ "$ADC_VALUE" -lt "$THRESHOLD" ]; then
+        CURRENT_STATE=0
+    else
+        CURRENT_STATE=1
+    fi
+
+    # Detect falling edge (button press event)
+    if [ "$LAST_STATE" -eq 1 ] && [ "$CURRENT_STATE" -eq 0 ]; then
+        echo "[KEY_MONITOR] Key Press Detected!"
+
+        # Trigger hotspot script
+        /usr/lib/vicharak-config/tui/comm/hotspot/start_hotspot.sh &
+    fi
+
+    LAST_STATE=$CURRENT_STATE
+
+    sleep $SLEEP_INTERVAL
+done

--- a/src/usr/lib/vicharak-config/tui/comm/hotspot/start_hotspot.sh
+++ b/src/usr/lib/vicharak-config/tui/comm/hotspot/start_hotspot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SSID="HOTSPOT"
+PASSWORD="12345678"
+
+echo "[HOTSPOT] Starting hotspot..."
+
+# Stop any existing hotspot
+nmcli connection down Hotspot 2>/dev/null
+
+# Create hotspot
+nmcli device wifi hotspot ifname wlan0 ssid "$SSID" password "$PASSWORD"
+
+echo "[HOTSPOT] Hotspot started: $SSID"


### PR DESCRIPTION
### Comm: Add hotspot recovery service and TUI integration

**What am I trying to fix?**
Users currently have no simple recovery mechanism to regain
network access when Wi-Fi configuration becomes inaccessible or
misconfigured.

**Why is this required?**
A recovery hotspot provides an easier way to access and configure
the device during setup, debugging, or network failure scenarios
without requiring manual terminal intervention.

**How have I implemented it?**
- Added hotspot configuration options in vicharak-config TUI
- Added a systemd service to monitor recovery key events
- Implemented ADC-based recovery button detection
- Added hotspot startup and credential management scripts using nmcli