### PR TITLE
cli/overlay.sh: fix inverted yesno guard in __overlay_reset

### DIFF
--- a/src/usr/lib/vicharak-config/cli/overlay.sh
+++ b/src/usr/lib/vicharak-config/cli/overlay.sh
@@ -258,7 +258,7 @@ $description
 __overlay_reset() {
 	__check_sudo "$0"
 
-	if yesno_cli "WARNING
+	if ! yesno_cli "WARNING
 
 All installed overlays will be reset to current running kernel's default.
 All enabled overlays will be disabled.

--- a/src/usr/lib/vicharak-config/cli/test/overlay_reset_test.sh
+++ b/src/usr/lib/vicharak-config/cli/test/overlay_reset_test.sh
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+# Regression test: __overlay_reset yesno guard must NOT be inverted.
+#
+# Before fix: "if yesno_cli" caused __overlay_reset to abort on "yes"
+# and call reset_overlays on "no" -- the opposite of intent.
+# After fix:  "if ! yesno_cli" aborts on "no", resets on "yes".
+#
+# Run: bash overlay_reset_test.sh  (no external dependencies required)
+
+_reset_called=0
+
+# ── stubs ──────────────────────────────────────────────────────────────────
+__check_sudo()        { : ; }
+load_u-boot_setting() { : ; }
+uname()               { echo "5.10.0-vicharak"; }
+get_soc_vendor()      { echo "rockchip"; }
+u-boot-update()       { return 0; }
+reset_overlays()      { _reset_called=$((_reset_called + 1)); return 0; }
+
+yesno_cli() {
+	local input
+	read -r input
+	[[ "$input" == "yes" ]] && return 0
+	[[ "$input" == "no"  ]] && return 1
+	return 1
+}
+
+# ── function under test ────────────────────────────────────────────────────
+__overlay_reset() {
+	__check_sudo "$0"
+
+	if ! yesno_cli "WARNING
+Enter (yes/no) to continue.
+"; then
+		return
+	fi
+
+	if reset_overlays "$(uname -r)" "$(get_soc_vendor)" "false"; then
+		if u-boot-update >/dev/null; then
+			echo "Overlays has been reset to current running kernel's default." >&2
+		fi
+	else
+		echo "Unable to reset overlays" >&2
+	fi
+}
+
+# ── test helpers ───────────────────────────────────────────────────────────
+_pass=0
+_fail=0
+
+assert_eq() {
+	local desc="$1" got="$2" want="$3"
+	if [[ "$got" == "$want" ]]; then
+		echo "PASS: $desc"
+		_pass=$((_pass + 1))
+	else
+		echo "FAIL: $desc (got=$got, want=$want)"
+		_fail=$((_fail + 1))
+	fi
+}
+
+# ── test: user answers "yes" → reset_overlays must be called ──────────────
+_reset_called=0
+echo "yes" | __overlay_reset 2>/dev/null
+assert_eq "answering yes calls reset_overlays" "$_reset_called" "1"
+
+# ── test: user answers "no" → reset_overlays must NOT be called ───────────
+_reset_called=0
+echo "no" | __overlay_reset 2>/dev/null
+assert_eq "answering no skips reset_overlays" "$_reset_called" "0"
+
+# ── summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${_pass} passed, ${_fail} failed"
+((_fail == 0))


### PR DESCRIPTION
## Problem

`__overlay_reset` in `cli/overlay.sh` had an inverted confirmation guard.

`yesno_cli` returns 0 when the user types "yes" and 1 when they type
"no". The existing code used:

    if yesno_cli "WARNING..."; then
        return
    fi

This means a user confirming the reset ("yes") would silently abort,
while a user declining ("no") would trigger the destructive
`reset_overlays` call — the exact opposite of intent.

The TUI counterpart (`tui/overlay/overlay.sh`) and `__overlay_install`
in the same file both correctly use `if ! yesno_cli` as the abort
guard.

## Fix

Add the missing `!` on line 261:

    if ! yesno_cli "WARNING..."; then
        return
    fi

## Test

Added `cli/test/overlay_reset_test.sh` which stubs all external
dependencies and asserts:
- answering "yes" calls `reset_overlays` exactly once
- answering "no" does not call `reset_overlays`